### PR TITLE
Search by Opcode, Row highlights by opcode, CM_Communication.cs adds

### DIFF
--- a/aclogview/App.config
+++ b/aclogview/App.config
@@ -1,6 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="aclogview.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+<userSettings>
+        <aclogview.Properties.Settings>
+            <setting name="FindOpcodeInFilesRoot" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="FindOpcodeInFilesOpcode" serializeAs="String">
+                <value>0</value>
+            </setting>
+        </aclogview.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/aclogview/CM_Communication.cs
+++ b/aclogview/CM_Communication.cs
@@ -13,13 +13,57 @@ public class CM_Communication : MessageProcessor {
 
         PacketOpcode opcode = Util.readOpcode(messageDataReader);
         switch (opcode) {
-            case PacketOpcode.Evt_Communication__WeenieError_ID: {
+            case PacketOpcode.Evt_Communication__TalkDirectByName_ID: // 0x005D
+                {
+                    var message = TalkDirectByName.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.Evt_Communication__ChannelBroadcast_ID: // 0x0147
+                {
+                    var message = ChannelBroadcast.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            /*case PacketOpcode.Evt_Communication__SetSquelchDB_ID: // 0x01F4
+                {
+                    var message = SetSquelchDB.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }*/
+            case PacketOpcode.Evt_Communication__WeenieError_ID: // 0x028A
+                {
                     WeenieError message = WeenieError.read(messageDataReader);
                     message.contributeToTreeView(outputTreeView);
                     break;
                 }
-            case PacketOpcode.Evt_Communication__WeenieErrorWithString_ID: {
+            case PacketOpcode.Evt_Communication__WeenieErrorWithString_ID: // 0x028B
+                {
                     WeenieErrorWithString message = WeenieErrorWithString.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.Evt_Communication__HearSpeech_ID: // 0x02BB
+                {
+                    var message = HearSpeech.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.Evt_Communication__HearRangedSpeech_ID: // 0x02BC
+                {
+                    var message = HearRangedSpeech.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.Evt_Communication__HearDirectSpeech_ID: // 0x2BD
+                {
+                    var message = HearDirectSpeech.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.Evt_Communication__TextboxString_ID: // 0xF7E0
+                {
+                    var message = TextBoxString.read(messageDataReader);
                     message.contributeToTreeView(outputTreeView);
                     break;
                 }
@@ -31,6 +75,70 @@ public class CM_Communication : MessageProcessor {
 
         return handled;
     }
+
+    public class TalkDirectByName : Message
+    {
+        public PStringChar MessageText;
+        public PStringChar TargetName;
+
+        public static TalkDirectByName read(BinaryReader binaryReader)
+        {
+            var newObj = new TalkDirectByName();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            newObj.TargetName = PStringChar.read(binaryReader);
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            rootNode.Nodes.Add("TargetName = " + TargetName.m_buffer);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class ChannelBroadcast : Message
+    {
+        public uint GroupChatType;
+        public uint Unknown;
+        public PStringChar MessageText;
+
+        public static ChannelBroadcast read(BinaryReader binaryReader)
+        {
+            var newObj = new ChannelBroadcast();
+            newObj.GroupChatType = binaryReader.ReadUInt32();
+            newObj.Unknown = binaryReader.ReadUInt32();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("GroupChatType = " + GroupChatType);
+            rootNode.Nodes.Add("Unknown = " + Unknown);
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    /*public class SetSquelchDB : Message
+    {
+        public static SetSquelchDB read(BinaryReader binaryReader)
+        {
+            var newObj = new SetSquelchDB();
+
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            throw new NotImplementedException();
+        }
+    }*/
 
     public class WeenieError : Message {
         public WERROR etype;
@@ -65,6 +173,125 @@ public class CM_Communication : MessageProcessor {
             rootNode.Expand();
             rootNode.Nodes.Add("etype = " + etype);
             rootNode.Nodes.Add("user_data = " + user_data);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class HearSpeech : Message
+    {
+        public PStringChar MessageText;
+        public PStringChar SenderName;
+        public uint SenderID;
+        public uint ChatMessageType;
+
+        public static HearSpeech read(BinaryReader binaryReader)
+        {
+            var newObj = new HearSpeech();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            newObj.SenderName = PStringChar.read(binaryReader);
+            newObj.SenderID = binaryReader.ReadUInt32();
+            newObj.ChatMessageType = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            rootNode.Nodes.Add("SenderName = " + SenderName.m_buffer);
+            rootNode.Nodes.Add("SenderID = " + SenderID);
+            rootNode.Nodes.Add("ChatMessageType = " + ChatMessageType);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class HearRangedSpeech : Message
+    {
+        public PStringChar MessageText;
+        public PStringChar SenderName;
+        public uint SenderID;
+        public float Range;
+        public uint ChatMessageType;
+
+        public static HearRangedSpeech read(BinaryReader binaryReader)
+        {
+            var newObj = new HearRangedSpeech();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            newObj.SenderName = PStringChar.read(binaryReader);
+            newObj.SenderID = binaryReader.ReadUInt32();
+            newObj.Range = binaryReader.ReadSingle();
+            newObj.ChatMessageType = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            rootNode.Nodes.Add("SenderName = " + SenderName.m_buffer);
+            rootNode.Nodes.Add("SenderID = " + SenderID);
+            rootNode.Nodes.Add("Range = " + Range);
+            rootNode.Nodes.Add("ChatMessageType = " + ChatMessageType);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class HearDirectSpeech : Message
+    {
+        public PStringChar MessageText;
+        public PStringChar SenderName;
+        public uint SenderID;
+        public uint TargetID;
+        public uint ChatMessageType;
+        public uint Unknown;
+
+        public static HearDirectSpeech read(BinaryReader binaryReader)
+        {
+            var newObj = new HearDirectSpeech();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            newObj.SenderName = PStringChar.read(binaryReader);
+            newObj.SenderID = binaryReader.ReadUInt32();
+            newObj.TargetID = binaryReader.ReadUInt32();
+            newObj.ChatMessageType = binaryReader.ReadUInt32();
+            newObj.Unknown = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            rootNode.Nodes.Add("SenderName = " + SenderName.m_buffer);
+            rootNode.Nodes.Add("SenderID = " + SenderID);
+            rootNode.Nodes.Add("TargetID = " + TargetID);
+            rootNode.Nodes.Add("ChatMessageType = " + ChatMessageType);
+            rootNode.Nodes.Add("Unknown = " + Unknown);
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class TextBoxString : Message
+    {
+        public PStringChar MessageText;
+        public uint ChatMessageType;
+
+        public static TextBoxString read(BinaryReader binaryReader)
+        {
+            var newObj = new TextBoxString();
+            newObj.MessageText = PStringChar.read(binaryReader);
+            newObj.ChatMessageType = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("MessageText = " + MessageText.m_buffer);
+            rootNode.Nodes.Add("ChatMessageType = " + ChatMessageType);
             treeView.Nodes.Add(rootNode);
         }
     }

--- a/aclogview/FindOpcodeInFilesForm.Designer.cs
+++ b/aclogview/FindOpcodeInFilesForm.Designer.cs
@@ -1,0 +1,231 @@
+﻿namespace aclogview
+{
+    partial class FindOpcodeInFilesForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.txtSearchPathRoot = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnStartSearch = new System.Windows.Forms.Button();
+            this.btnStopSearch = new System.Windows.Forms.Button();
+            this.btnChangeSearchPathRoot = new System.Windows.Forms.Button();
+            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtOpcode = new System.Windows.Forms.TextBox();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.columnHits = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnFileSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.statusStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // txtSearchPathRoot
+            // 
+            this.txtSearchPathRoot.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSearchPathRoot.Location = new System.Drawing.Point(15, 25);
+            this.txtSearchPathRoot.Name = "txtSearchPathRoot";
+            this.txtSearchPathRoot.Size = new System.Drawing.Size(723, 20);
+            this.txtSearchPathRoot.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(92, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Search Path Root";
+            // 
+            // btnStartSearch
+            // 
+            this.btnStartSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStartSearch.Location = new System.Drawing.Point(524, 51);
+            this.btnStartSearch.Name = "btnStartSearch";
+            this.btnStartSearch.Size = new System.Drawing.Size(121, 23);
+            this.btnStartSearch.TabIndex = 2;
+            this.btnStartSearch.Text = "Start Search";
+            this.btnStartSearch.UseVisualStyleBackColor = true;
+            this.btnStartSearch.Click += new System.EventHandler(this.btnStartSearch_Click);
+            // 
+            // btnStopSearch
+            // 
+            this.btnStopSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStopSearch.Enabled = false;
+            this.btnStopSearch.Location = new System.Drawing.Point(651, 51);
+            this.btnStopSearch.Name = "btnStopSearch";
+            this.btnStopSearch.Size = new System.Drawing.Size(121, 23);
+            this.btnStopSearch.TabIndex = 3;
+            this.btnStopSearch.Text = "Stop Search";
+            this.btnStopSearch.UseVisualStyleBackColor = true;
+            this.btnStopSearch.Click += new System.EventHandler(this.btnStopSearch_Click);
+            // 
+            // btnChangeSearchPathRoot
+            // 
+            this.btnChangeSearchPathRoot.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnChangeSearchPathRoot.Location = new System.Drawing.Point(744, 23);
+            this.btnChangeSearchPathRoot.Name = "btnChangeSearchPathRoot";
+            this.btnChangeSearchPathRoot.Size = new System.Drawing.Size(28, 23);
+            this.btnChangeSearchPathRoot.TabIndex = 4;
+            this.btnChangeSearchPathRoot.Text = "F";
+            this.btnChangeSearchPathRoot.UseVisualStyleBackColor = true;
+            this.btnChangeSearchPathRoot.Click += new System.EventHandler(this.btnChangeSearchPathRoot_Click);
+            // 
+            // dataGridView1
+            // 
+            this.dataGridView1.AllowUserToAddRows = false;
+            this.dataGridView1.AllowUserToDeleteRows = false;
+            this.dataGridView1.AllowUserToResizeColumns = false;
+            this.dataGridView1.AllowUserToResizeRows = false;
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.columnHits,
+            this.columnFileSize,
+            this.columnFilePath});
+            this.dataGridView1.Location = new System.Drawing.Point(15, 80);
+            this.dataGridView1.Name = "dataGridView1";
+            this.dataGridView1.ReadOnly = true;
+            this.dataGridView1.Size = new System.Drawing.Size(757, 456);
+            this.dataGridView1.TabIndex = 5;
+            this.dataGridView1.CellContentDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellContentDoubleClick);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 56);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(59, 13);
+            this.label2.TabIndex = 6;
+            this.label2.Text = "Opcode 0x";
+            // 
+            // txtOpcode
+            // 
+            this.txtOpcode.Location = new System.Drawing.Point(77, 53);
+            this.txtOpcode.Name = "txtOpcode";
+            this.txtOpcode.Size = new System.Drawing.Size(64, 20);
+            this.txtOpcode.TabIndex = 7;
+            this.txtOpcode.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabel1});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 539);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(784, 22);
+            this.statusStrip1.TabIndex = 8;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(89, 17);
+            this.toolStripStatusLabel1.Text = "Files Processed:";
+            // 
+            // timer1
+            // 
+            this.timer1.Interval = 200;
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            // 
+            // columnHits
+            // 
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle7.Format = "N0";
+            this.columnHits.DefaultCellStyle = dataGridViewCellStyle7;
+            this.columnHits.HeaderText = "Hits";
+            this.columnHits.Name = "columnHits";
+            this.columnHits.ReadOnly = true;
+            this.columnHits.Width = 60;
+            // 
+            // columnFileSize
+            // 
+            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle8.Format = "N0";
+            this.columnFileSize.DefaultCellStyle = dataGridViewCellStyle8;
+            this.columnFileSize.HeaderText = "File Size";
+            this.columnFileSize.Name = "columnFileSize";
+            this.columnFileSize.ReadOnly = true;
+            this.columnFileSize.Width = 80;
+            // 
+            // columnFilePath
+            // 
+            this.columnFilePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.columnFilePath.HeaderText = "File Path";
+            this.columnFilePath.Name = "columnFilePath";
+            this.columnFilePath.ReadOnly = true;
+            // 
+            // FindOpcodeInFilesForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(784, 561);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.txtOpcode);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.dataGridView1);
+            this.Controls.Add(this.btnChangeSearchPathRoot);
+            this.Controls.Add(this.btnStopSearch);
+            this.Controls.Add(this.btnStartSearch);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.txtSearchPathRoot);
+            this.Name = "FindOpcodeInFilesForm";
+            this.Text = "Find Opcode In Files";
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox txtSearchPathRoot;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button btnStartSearch;
+        private System.Windows.Forms.Button btnStopSearch;
+        private System.Windows.Forms.Button btnChangeSearchPathRoot;
+        private System.Windows.Forms.DataGridView dataGridView1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox txtOpcode;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
+        private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnHits;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnFileSize;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnFilePath;
+    }
+}

--- a/aclogview/FindOpcodeInFilesForm.Designer.cs
+++ b/aclogview/FindOpcodeInFilesForm.Designer.cs
@@ -29,22 +29,22 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             this.txtSearchPathRoot = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.btnStartSearch = new System.Windows.Forms.Button();
             this.btnStopSearch = new System.Windows.Forms.Button();
             this.btnChangeSearchPathRoot = new System.Windows.Forms.Button();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.columnHits = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnFileSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label2 = new System.Windows.Forms.Label();
             this.txtOpcode = new System.Windows.Forms.TextBox();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.columnHits = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnFileSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.columnFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -122,6 +122,33 @@
             this.dataGridView1.TabIndex = 5;
             this.dataGridView1.CellContentDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellContentDoubleClick);
             // 
+            // columnHits
+            // 
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle1.Format = "N0";
+            this.columnHits.DefaultCellStyle = dataGridViewCellStyle1;
+            this.columnHits.HeaderText = "Hits";
+            this.columnHits.Name = "columnHits";
+            this.columnHits.ReadOnly = true;
+            this.columnHits.Width = 60;
+            // 
+            // columnFileSize
+            // 
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle2.Format = "N0";
+            this.columnFileSize.DefaultCellStyle = dataGridViewCellStyle2;
+            this.columnFileSize.HeaderText = "File Size";
+            this.columnFileSize.Name = "columnFileSize";
+            this.columnFileSize.ReadOnly = true;
+            this.columnFileSize.Width = 80;
+            // 
+            // columnFilePath
+            // 
+            this.columnFilePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.columnFilePath.HeaderText = "File Path";
+            this.columnFilePath.Name = "columnFilePath";
+            this.columnFilePath.ReadOnly = true;
+            // 
             // label2
             // 
             this.label2.AutoSize = true;
@@ -159,33 +186,6 @@
             // 
             this.timer1.Interval = 200;
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-            // 
-            // columnHits
-            // 
-            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
-            dataGridViewCellStyle7.Format = "N0";
-            this.columnHits.DefaultCellStyle = dataGridViewCellStyle7;
-            this.columnHits.HeaderText = "Hits";
-            this.columnHits.Name = "columnHits";
-            this.columnHits.ReadOnly = true;
-            this.columnHits.Width = 60;
-            // 
-            // columnFileSize
-            // 
-            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
-            dataGridViewCellStyle8.Format = "N0";
-            this.columnFileSize.DefaultCellStyle = dataGridViewCellStyle8;
-            this.columnFileSize.HeaderText = "File Size";
-            this.columnFileSize.Name = "columnFileSize";
-            this.columnFileSize.ReadOnly = true;
-            this.columnFileSize.Width = 80;
-            // 
-            // columnFilePath
-            // 
-            this.columnFilePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.columnFilePath.HeaderText = "File Path";
-            this.columnFilePath.Name = "columnFilePath";
-            this.columnFilePath.ReadOnly = true;
             // 
             // FindOpcodeInFilesForm
             // 

--- a/aclogview/FindOpcodeInFilesForm.cs
+++ b/aclogview/FindOpcodeInFilesForm.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -33,6 +34,10 @@ namespace aclogview
             dataGridView1.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             dataGridView1.Columns[0].ValueType = typeof(int);
             dataGridView1.Columns[1].ValueType = typeof(int);
+
+            // Center to our owner, if we have one
+            if (Owner != null)
+                Location = new Point(Owner.Location.X + Owner.Width / 2 - Width / 2, Owner.Location.Y + Owner.Height / 2 - Height / 2);
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -207,9 +212,12 @@ namespace aclogview
 
         private void dataGridView1_CellContentDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
+            if (e.RowIndex == -1)
+                return;
+
             var fileName = (string)dataGridView1.Rows[e.RowIndex].Cells[2].Value;
 
-            System.Diagnostics.Process.Start(Application.ExecutablePath, '"' + fileName + '"');
+            System.Diagnostics.Process.Start(Application.ExecutablePath, '"' + fileName + '"' + " " + opCodeToSearchFor);
         }
     }
 }

--- a/aclogview/FindOpcodeInFilesForm.cs
+++ b/aclogview/FindOpcodeInFilesForm.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using aclogview.Properties;
+
+namespace aclogview
+{
+    public partial class FindOpcodeInFilesForm : Form
+    {
+        public FindOpcodeInFilesForm()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            txtSearchPathRoot.Text = Settings.Default.FindOpcodeInFilesRoot;
+            txtOpcode.Text = Settings.Default.FindOpcodeInFilesOpcode.ToString("X4");
+
+            typeof(DataGridView).InvokeMember("DoubleBuffered", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetProperty, null, dataGridView1, new object[] { true });
+            dataGridView1.RowHeadersVisible = false;
+            dataGridView1.AllowUserToAddRows = false;
+            dataGridView1.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            dataGridView1.Columns[0].ValueType = typeof(int);
+            dataGridView1.Columns[1].ValueType = typeof(int);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            searchAborted = true;
+
+            Settings.Default.FindOpcodeInFilesRoot = txtSearchPathRoot.Text;
+            Settings.Default.FindOpcodeInFilesOpcode = OpCode;
+
+            base.OnClosing(e);
+        }
+
+        int OpCode
+        {
+            get
+            {
+                int value;
+
+                int.TryParse(txtOpcode.Text, NumberStyles.HexNumber, null, out value);
+
+                return value;
+            }
+        }
+
+        private void btnChangeSearchPathRoot_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
+            {
+                if (openFolder.ShowDialog() == DialogResult.OK)
+                    txtSearchPathRoot.Text = openFolder.SelectedPath;
+            }
+        }
+
+
+        private readonly List<string> filesToProcess = new List<string>();
+        private int opCodeToSearchFor;
+        private int filesProcessed;
+        private bool searchAborted;
+
+        private class ProcessFileResut
+        {
+            public int Hits;
+            public string FileName;
+        }
+
+        private readonly ConcurrentBag<ProcessFileResut> processFileResuts = new ConcurrentBag<ProcessFileResut>();
+
+        private void btnStartSearch_Click(object sender, EventArgs e)
+        {
+            dataGridView1.RowCount = 0;
+
+            try
+            {
+                btnStartSearch.Enabled = false;
+
+                filesToProcess.Clear();
+                opCodeToSearchFor = OpCode;
+                filesProcessed = 0;
+                searchAborted = false;
+
+                ProcessFileResut result;
+                while (!processFileResuts.IsEmpty)
+                    processFileResuts.TryTake(out result);
+
+                filesToProcess.AddRange(Directory.GetFiles(txtSearchPathRoot.Text, "*.pcap", SearchOption.AllDirectories));
+                filesToProcess.AddRange(Directory.GetFiles(txtSearchPathRoot.Text, "*.pcapng", SearchOption.AllDirectories));
+
+                toolStripStatusLabel1.Text = "Files Processed: 0 of " + filesToProcess.Count;
+
+                txtSearchPathRoot.Enabled = false;
+                txtOpcode.Enabled = false;
+                btnChangeSearchPathRoot.Enabled = false;
+                btnStopSearch.Enabled = true;
+
+                timer1.Start();
+
+                new Thread(() =>
+                {
+                    // Do the actual search here
+                    DoSearch();
+
+                    if (!Disposing && !IsDisposed)
+                        btnStopSearch.BeginInvoke((Action)(() => btnStopSearch_Click(null, null)));
+                }).Start();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+
+                btnStopSearch_Click(null, null);
+            }
+        }
+
+        private void btnStopSearch_Click(object sender, EventArgs e)
+        {
+            searchAborted = true;
+
+            timer1.Stop();
+
+            timer1_Tick(null, null);
+
+            txtSearchPathRoot.Enabled = true;
+            txtOpcode.Enabled = true;
+            btnChangeSearchPathRoot.Enabled = true;
+            btnStartSearch.Enabled = true;
+            btnStopSearch.Enabled = false;
+        }
+
+
+        private void DoSearch()
+        {
+            Parallel.ForEach(filesToProcess, (currentFile) =>
+            {
+                if (searchAborted || Disposing || IsDisposed)
+                    return;
+
+                try
+                {
+                    ProcessFile(currentFile);
+                }
+                catch { }
+            });
+        }
+
+        private void ProcessFile(string fileName)
+        {
+            int hits = 0;
+
+            var records = PCapReader.LoadPcap(fileName, ref searchAborted);
+
+            if (searchAborted || Disposing || IsDisposed)
+                return;
+
+            foreach (var record in records)
+            {
+                if (record.opcodes.Contains((PacketOpcode)opCodeToSearchFor))
+                    hits++;
+
+                /*foreach (BlobFrag frag in record.netPacket.fragList_)
+                {
+                    if (frag.dat_.Length > 20)
+                    {
+                        BinaryReader fragDataReader = new BinaryReader(new MemoryStream(frag.dat_));
+
+                        // Custom search can go here
+                    }
+                }*/
+            }
+
+            Interlocked.Increment(ref filesProcessed);
+
+            processFileResuts.Add(new ProcessFileResut() { Hits = hits, FileName = fileName });
+        }
+
+        private void timer1_Tick(object sender, EventArgs e)
+        {
+            ProcessFileResut result;
+            while (!processFileResuts.IsEmpty)
+            {
+                if (processFileResuts.TryTake(out result))
+                {
+                    var length = new FileInfo(result.FileName).Length;
+
+                    if (result.Hits > 0)
+                        dataGridView1.Rows.Add(result.Hits, length, result.FileName);
+                }
+            }
+
+            toolStripStatusLabel1.Text = "Files Processed: " + filesProcessed + " of " + filesToProcess.Count;
+        }
+
+
+        private void dataGridView1_CellContentDoubleClick(object sender, DataGridViewCellEventArgs e)
+        {
+            var fileName = (string)dataGridView1.Rows[e.RowIndex].Cells[2].Value;
+
+            System.Diagnostics.Process.Start(Application.ExecutablePath, '"' + fileName + '"');
+        }
+    }
+}

--- a/aclogview/FindOpcodeInFilesForm.resx
+++ b/aclogview/FindOpcodeInFilesForm.resx
@@ -117,16 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="columnHits.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="columnFileSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="columnFilePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>134, 17</value>
-  </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>249, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>56</value>
+  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>133, 17</value>
   </metadata>
 </root>

--- a/aclogview/Form1.Designer.cs
+++ b/aclogview/Form1.Designer.cs
@@ -44,6 +44,7 @@
             this.menuItem_ToolCount = new System.Windows.Forms.MenuItem();
             this.menuItem_ToolBad = new System.Windows.Forms.MenuItem();
             this.menuItem_ToolHeatmap = new System.Windows.Forms.MenuItem();
+            this.mnuItem_ToolFindOpcodeInFiles = new System.Windows.Forms.MenuItem();
             this.menuItem_Help = new System.Windows.Forms.MenuItem();
             this.menuItem_About = new System.Windows.Forms.MenuItem();
             this.menuStrip = new System.Windows.Forms.MenuStrip();
@@ -211,7 +212,8 @@
             this.menuItem1.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.menuItem_ToolCount,
             this.menuItem_ToolBad,
-            this.menuItem_ToolHeatmap});
+            this.menuItem_ToolHeatmap,
+            this.mnuItem_ToolFindOpcodeInFiles});
             this.menuItem1.Text = "Tools";
             // 
             // menuItem_ToolCount
@@ -231,6 +233,12 @@
             this.menuItem_ToolHeatmap.Index = 2;
             this.menuItem_ToolHeatmap.Text = "Heatmap";
             this.menuItem_ToolHeatmap.Click += new System.EventHandler(this.menuItem_ToolHeatmap_Click);
+            // 
+            // mnuItem_ToolFindOpcodeInFiles
+            // 
+            this.mnuItem_ToolFindOpcodeInFiles.Index = 3;
+            this.mnuItem_ToolFindOpcodeInFiles.Text = "Find Opcode In Files";
+            this.mnuItem_ToolFindOpcodeInFiles.Click += new System.EventHandler(this.mnuItem_ToolFindOpcodeInFiles_Click);
             // 
             // menuItem_Help
             // 
@@ -362,6 +370,7 @@
         private System.Windows.Forms.MenuItem menuItem_ToolCount;
         private System.Windows.Forms.MenuItem menuItem_ToolBad;
         private System.Windows.Forms.MenuItem menuItem_ToolHeatmap;
+        private System.Windows.Forms.MenuItem mnuItem_ToolFindOpcodeInFiles;
     }
 }
 

--- a/aclogview/Form1.cs
+++ b/aclogview/Form1.cs
@@ -11,14 +11,20 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
+using aclogview.Properties;
+
 namespace aclogview {
     public partial class Form1 : Form {
         private ListViewItemComparer comparer = new ListViewItemComparer();
         public List<MessageProcessor> messageProcessors = new List<MessageProcessor>();
         private long curPacket;
 
-        public Form1() {
+        private string[] args;
+
+        public Form1(string[] args) {
             InitializeComponent();
+
+            this.args = args;
         }
 
         private void Form1_Load(object sender, EventArgs e) {
@@ -47,6 +53,16 @@ namespace aclogview {
             messageProcessors.Add(new CM_Vendor());
             messageProcessors.Add(new CM_Writing());
             messageProcessors.Add(new Proto_UI());
+
+            if (args != null && args.Length == 1)
+                loadPcap(args[0]);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            base.OnClosing(e);
+
+            Settings.Default.Save();
         }
 
         private void menuItem5_Click(object sender, EventArgs e) {
@@ -59,19 +75,6 @@ namespace aclogview {
             }
 
             loadPcap(openFile.FileName);
-        }
-
-        class PacketRecord {
-            public int index;
-            public bool isSend;
-            public uint tsSec;
-            public string packetHeadersStr;
-            public string packetTypeStr;
-            public byte[] data;
-            public int optionalHeadersLen;
-            public NetPacket netPacket;
-            public List<PacketOpcode> opcodes = new List<PacketOpcode>();
-            public string extraInfo;
         }
 
         private void readPacket(PacketRecord packet, StringBuilder packetTypeStr, BinaryReader packetReader) {
@@ -924,6 +927,12 @@ namespace aclogview {
             popup.ClientSize = new Size(512, 512);
             popup.setImage(heatmapImg);
             popup.ShowDialog();
+        }
+
+        private void mnuItem_ToolFindOpcodeInFiles_Click(object sender, EventArgs e)
+        {
+            var form = new FindOpcodeInFilesForm();
+            form.Show();
         }
     }
 }

--- a/aclogview/PCapReader.cs
+++ b/aclogview/PCapReader.cs
@@ -1,0 +1,409 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace aclogview
+{
+    static class PCapReader
+    {
+        public static List<PacketRecord> LoadPcap(string fileName, ref bool abort)
+        {
+            using (FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                using (BinaryReader binaryReader = new BinaryReader(fileStream))
+                {
+                    uint magicNumber = binaryReader.ReadUInt32();
+
+                    binaryReader.BaseStream.Position = 0;
+
+                    if (magicNumber == 0xA1B2C3D4 || magicNumber == 0xD4C3B2A1)
+                        return loadPcapContent(binaryReader, ref abort);
+
+                    return loadPcapngContent(binaryReader, ref abort);
+                }
+            }
+        }
+
+        private static List<PacketRecord> loadPcapContent(BinaryReader binaryReader, ref bool abort)
+        {
+            List<PacketRecord> results = new List<PacketRecord>();
+
+            /*PcapHeader pcapHeader = */
+            PcapHeader.read(binaryReader);
+
+            int curPacket = 0;
+
+            while (binaryReader.BaseStream.Position != binaryReader.BaseStream.Length)
+            {
+                if (abort)
+                    break;
+
+                curPacket++;
+
+                if (binaryReader.BaseStream.Length - binaryReader.BaseStream.Position < 16)
+                {
+                    //MessageBox.Show("Stream cut short (packet " + curPacket + "), stopping read: " + (binaryReader.BaseStream.Length - binaryReader.BaseStream.Position));
+                    break;
+                }
+
+                PcapRecordHeader recordHeader = PcapRecordHeader.read(binaryReader);
+
+                if (recordHeader.inclLen > 50000)
+                {
+                    //MessageBox.Show("Enormous packet (packet " + curPacket + "), stopping read: " + recordHeader.inclLen);
+                    break;
+                }
+
+                // Make sure there's enough room for an ethernet header
+                if (recordHeader.inclLen < 14)
+                {
+                    binaryReader.BaseStream.Position += recordHeader.inclLen;
+                    continue;
+                }
+
+                var packetRecord = readPacketRecordData(binaryReader, recordHeader.inclLen, recordHeader.tsSec, curPacket);
+
+                if (packetRecord == null)
+                    break;
+
+                results.Add(packetRecord);
+            }
+
+            return results;
+        }
+
+        private static List<PacketRecord> loadPcapngContent(BinaryReader binaryReader, ref bool abort)
+        {
+            List<PacketRecord> results = new List<PacketRecord>();
+
+            int curPacket = 0;
+
+            while (binaryReader.BaseStream.Position != binaryReader.BaseStream.Length)
+            {
+                if (abort)
+                    break;
+
+                curPacket++;
+
+                if (binaryReader.BaseStream.Length - binaryReader.BaseStream.Position < 8)
+                {
+                    //MessageBox.Show("Stream cut short (packet " + curPacket + "), stopping read: " + (binaryReader.BaseStream.Length - binaryReader.BaseStream.Position));
+                    break;
+                }
+
+                long recordStartPos = binaryReader.BaseStream.Position;
+
+                uint blockType = binaryReader.ReadUInt32();
+                uint blockTotalLength = binaryReader.ReadUInt32();
+
+                if (blockType == 6)
+                {
+                    /*uint interfaceID = */binaryReader.ReadUInt32();
+                    /*uint tsHigh = */binaryReader.ReadUInt32();
+                    uint tsLow = binaryReader.ReadUInt32();
+                    uint capturedLen = binaryReader.ReadUInt32();
+                    /*uint packetLen = */binaryReader.ReadUInt32();
+
+                    var packetRecord = readPacketRecordData(binaryReader, capturedLen, tsLow, curPacket);
+
+                    if (packetRecord == null)
+                        break;
+
+                    results.Add(packetRecord);
+                }
+                else if (blockType == 3)
+                {
+                    /*uint packetLen = */binaryReader.ReadUInt32();
+                    uint capturedLen = blockTotalLength - 16;
+
+                    var packetRecord = readPacketRecordData(binaryReader, capturedLen, 0, curPacket);
+
+                    if (packetRecord == null)
+                        break;
+
+                    results.Add(packetRecord);
+                }
+
+                binaryReader.BaseStream.Position += blockTotalLength - (binaryReader.BaseStream.Position - recordStartPos);
+            }
+
+            return results;
+        }
+
+        private static PacketRecord readPacketRecordData(BinaryReader binaryReader, long len, uint tsSec, int curPacket)
+        {
+            // Begin reading headers
+            long packetStartPos = binaryReader.BaseStream.Position;
+
+            EthernetHeader ethernetHeader = EthernetHeader.read(binaryReader);
+
+            // Skip non-IP packets
+            if (ethernetHeader.proto != 8)
+            {
+                binaryReader.BaseStream.Position += len - (binaryReader.BaseStream.Position - packetStartPos);
+                return null;
+            }
+
+            IpHeader ipHeader = IpHeader.read(binaryReader);
+
+            // Skip non-UDP packets
+            if (ipHeader.proto != 17)
+            {
+                binaryReader.BaseStream.Position += len - (binaryReader.BaseStream.Position - packetStartPos);
+                return null;
+            }
+
+            UdpHeader udpHeader = UdpHeader.read(binaryReader);
+
+            bool isSend = (udpHeader.dPort >= 9000 && udpHeader.dPort <= 9013);
+            bool isRecv = (udpHeader.sPort >= 9000 && udpHeader.sPort <= 9013);
+
+            // Skip non-AC-port packets
+            if (!isSend && !isRecv)
+            {
+                binaryReader.BaseStream.Position += len - (binaryReader.BaseStream.Position - packetStartPos);
+                return null;
+            }
+
+            long headersSize = binaryReader.BaseStream.Position - packetStartPos;
+
+            // Begin reading non-header packet content
+            StringBuilder packetHeadersStr = new StringBuilder();
+            StringBuilder packetTypeStr = new StringBuilder();
+
+            PacketRecord packet = new PacketRecord();
+            packet.index = (curPacket - 1);
+            packet.isSend = isSend;
+            packet.tsSec = tsSec;
+            packet.netPacket = new NetPacket();
+            packet.data = binaryReader.ReadBytes((int)(len - headersSize));
+            packet.extraInfo = "";
+            BinaryReader packetReader = new BinaryReader(new MemoryStream(packet.data));
+            try
+            {
+                ProtoHeader pHeader = ProtoHeader.read(packetReader);
+
+                readOptionalHeaders(packet, pHeader.header_, packetHeadersStr, packetReader);
+
+                if (packetReader.BaseStream.Position == packetReader.BaseStream.Length)
+                    packetTypeStr.Append("<Header Only>");
+
+                uint HAS_FRAGS_MASK = 0x4; // See SharedNet::SplitPacketData
+
+                if ((pHeader.header_ & HAS_FRAGS_MASK) != 0)
+                {
+                    bool first = true;
+
+                    while (packetReader.BaseStream.Position != packetReader.BaseStream.Length)
+                    {
+                        if (!first)
+                            packetTypeStr.Append(" + ");
+
+                        readPacket(packet, packetTypeStr, packetReader);
+                        first = false;
+                    }
+                }
+
+                if (packetReader.BaseStream.Position != packetReader.BaseStream.Length)
+                    packet.extraInfo = "Didnt read entire packet! " + packet.extraInfo;
+            }
+            catch (OutOfMemoryException e)
+            {
+                //MessageBox.Show("Out of memory (packet " + curPacket + "), stopping read: " + e);
+                return null;
+            }
+            catch (Exception e)
+            {
+                packet.extraInfo += "EXCEPTION: " + e.Message + " " + e.StackTrace;
+            }
+
+            packet.packetHeadersStr = packetHeadersStr.ToString();
+            packet.packetTypeStr = packetTypeStr.ToString();
+
+            return packet;
+        }
+
+        private static void readPacket(PacketRecord packet, StringBuilder packetTypeStr, BinaryReader packetReader)
+        {
+            BlobFrag newFrag = new BlobFrag();
+            newFrag.memberHeader_ = BlobFragHeader_t.read(packetReader);
+            newFrag.dat_ = packetReader.ReadBytes(newFrag.memberHeader_.blobFragSize - 16); // 16 == size of frag header
+
+            packet.netPacket.fragList_.Add(newFrag);
+
+            BinaryReader fragDataReader = new BinaryReader(new MemoryStream(newFrag.dat_));
+
+            if (newFrag.memberHeader_.blobNum != 0)
+            {
+                packetTypeStr.Append("FragData[");
+                packetTypeStr.Append(newFrag.memberHeader_.blobNum);
+                packetTypeStr.Append("]");
+            }
+            else
+            {
+                PacketOpcode opcode = Util.readOpcode(fragDataReader);
+                packet.opcodes.Add(opcode);
+                packetTypeStr.Append(opcode);
+            }
+        }
+
+        private static void readOptionalHeaders(PacketRecord packet, uint header_, StringBuilder packetHeadersStr, BinaryReader packetReader)
+        {
+            long readStartPos = packetReader.BaseStream.Position;
+
+            if ((header_ & CServerSwitchStructHeader.mask) != 0)
+            {
+                /*CServerSwitchStruct serverSwitchStruct = */CServerSwitchStruct.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Server Switch");
+            }
+
+            if ((header_ & LogonServerAddrHeader.mask) != 0)
+            {
+                /*sockaddr_in serverAddr = */sockaddr_in.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Logon Server Addr");
+            }
+
+            if ((header_ & CEmptyHeader1.mask) != 0)
+            {
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Empty Header 1");
+            }
+
+            if ((header_ & CReferralStructHeader.mask) != 0)
+            {
+                /*CReferralStruct referralStruct = */CReferralStruct.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Referral");
+            }
+
+            if ((header_ & NakHeader.mask) != 0)
+            {
+                /*CSeqIDListHeader nakSeqIDs = */NakHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Nak");
+            }
+
+            if ((header_ & EmptyAckHeader.mask) != 0)
+            {
+                /*CSeqIDListHeader ackSeqIDs = */EmptyAckHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Empty Ack");
+            }
+
+            if ((header_ & PakHeader.mask) != 0)
+            {
+                /*PakHeader pakHeader = */PakHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Pak");
+            }
+
+            if ((header_ & CEmptyHeader2.mask) != 0)
+            {
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Empty Header 2");
+            }
+
+            if ((header_ & CLogonHeader.mask) != 0)
+            {
+                CLogonHeader.HandshakeWireData handshakeData = CLogonHeader.HandshakeWireData.read(packetReader);
+                /*byte[] authData = */packetReader.ReadBytes((int)handshakeData.cbAuthData);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Logon");
+            }
+
+            if ((header_ & ULongHeader.mask) != 0)
+            {
+                /*ULongHeader ulongHeader = */ULongHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("ULong 1");
+            }
+
+            if ((header_ & CConnectHeader.mask) != 0)
+            {
+                /*CConnectHeader.HandshakeWireData handshakeData = */CConnectHeader.HandshakeWireData.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Connect");
+            }
+
+            if ((header_ & ULongHeader2.mask) != 0)
+            {
+                /*ULongHeader2 ulongHeader = */ULongHeader2.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("ULong 2");
+            }
+
+            if ((header_ & NetErrorHeader.mask) != 0)
+            {
+                /*NetError netError = */NetError.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Net Error");
+            }
+
+            if ((header_ & NetErrorHeader_cs_DisconnectReceived.mask) != 0)
+            {
+                /*NetError netError = */NetError.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Net Error Disconnect");
+            }
+
+            if ((header_ & CICMDCommandStructHeader.mask) != 0)
+            {
+                /*CICMDCommandStruct icmdStruct = */CICMDCommandStruct.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("ICmd");
+            }
+
+            if ((header_ & CTimeSyncHeader.mask) != 0)
+            {
+                /*CTimeSyncHeader timeSyncHeader = */CTimeSyncHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Time Sync");
+            }
+
+            if ((header_ & CEchoRequestHeader.mask) != 0)
+            {
+                /*CEchoRequestHeader echoRequestHeader = */CEchoRequestHeader.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Echo Request");
+            }
+
+            if ((header_ & CEchoResponseHeader.mask) != 0)
+            {
+                /*CEchoResponseHeader.CEchoResponseHeaderWireData echoResponseData = */CEchoResponseHeader.CEchoResponseHeaderWireData.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Echo Response");
+            }
+
+            if ((header_ & CFlowStructHeader.mask) != 0)
+            {
+                /*CFlowStruct flowStruct = */CFlowStruct.read(packetReader);
+                if (packetHeadersStr.Length != 0)
+                    packetHeadersStr.Append(" | ");
+                packetHeadersStr.Append("Flow");
+            }
+
+            packet.optionalHeadersLen = (int)(packetReader.BaseStream.Position - readStartPos);
+        }
+    }
+}

--- a/aclogview/PacketRecord.cs
+++ b/aclogview/PacketRecord.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace aclogview
+{
+    class PacketRecord
+    {
+        public int index;
+        public bool isSend;
+        public uint tsSec;
+        public string packetHeadersStr;
+        public string packetTypeStr;
+        public byte[] data;
+        public int optionalHeadersLen;
+        public NetPacket netPacket;
+        public List<PacketOpcode> opcodes = new List<PacketOpcode>();
+        public string extraInfo;
+    }
+}

--- a/aclogview/Program.cs
+++ b/aclogview/Program.cs
@@ -10,10 +10,10 @@ namespace aclogview {
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main() {
+        static void Main(string[] args) {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.Run(new Form1(args));
         }
     }
 }

--- a/aclogview/Properties/Settings.Designer.cs
+++ b/aclogview/Properties/Settings.Designer.cs
@@ -9,17 +9,41 @@
 //------------------------------------------------------------------------------
 
 namespace aclogview.Properties {
-
-
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
+        
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string FindOpcodeInFilesRoot {
+            get {
+                return ((string)(this["FindOpcodeInFilesRoot"]));
+            }
+            set {
+                this["FindOpcodeInFilesRoot"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int FindOpcodeInFilesOpcode {
+            get {
+                return ((int)(this["FindOpcodeInFilesOpcode"]));
+            }
+            set {
+                this["FindOpcodeInFilesOpcode"] = value;
             }
         }
     }

--- a/aclogview/Properties/Settings.settings
+++ b/aclogview/Properties/Settings.settings
@@ -1,7 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="aclogview.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="FindOpcodeInFilesRoot" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="FindOpcodeInFilesOpcode" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -96,6 +96,12 @@
     <Compile Include="Enums\Trade.cs" />
     <Compile Include="Enums\UI.cs" />
     <Compile Include="Enums\WeenieError.cs" />
+    <Compile Include="FindOpcodeInFilesForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FindOpcodeInFilesForm.Designer.cs">
+      <DependentUpon>FindOpcodeInFilesForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -110,8 +116,10 @@
     </Compile>
     <Compile Include="PacketHeaders.cs" />
     <Compile Include="PacketOpcode.cs" />
+    <Compile Include="PacketRecord.cs" />
     <Compile Include="Packets.cs" />
     <Compile Include="pcap.cs" />
+    <Compile Include="PCapReader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto_UI.cs" />
@@ -123,6 +131,9 @@
     <Compile Include="TextPopup.Designer.cs">
       <DependentUpon>TextPopup.cs</DependentUpon>
     </Compile>
+    <EmbeddedResource Include="FindOpcodeInFilesForm.resx">
+      <DependentUpon>FindOpcodeInFilesForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>
@@ -152,7 +163,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="map.png" />


### PR DESCRIPTION
This makes finding a pcap with a specific opcode much easier.

You can double click the results to open up a new aclogviewer instance for that particular pcap, and the rows with the opcode you're looking for will be highlighted in the main list.

Functionality is also added to do live row highlighting by opcode, from a UI change. I have not implemented the UI though. All you need to do is update opCodesToHighlight and then call listView_Packets.RedrawItems(0, records.Count - 1, false);
updateData();