### PR TITLE
Inventory's Wield Object Event and Remove Object Event messages

### DIFF
--- a/aclogview/CM_Inventory.cs
+++ b/aclogview/CM_Inventory.cs
@@ -15,6 +15,18 @@ public class CM_Inventory : MessageProcessor {
 
         PacketOpcode opcode = Util.readOpcode(messageDataReader);
         switch (opcode) {
+            case PacketOpcode.INVENTORY_WIELD_OBJ_EVENT: // 0x0023
+                {
+                    WieldItem message = WieldItem.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
+            case PacketOpcode.INVENTORY_REMOVE_OBJ_EVENT: // 0x0024
+                {
+                    RemoveObject message = RemoveObject.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
             case PacketOpcode.Evt_Inventory__PutItemInContainer_ID: {
                     PutItemInContainer message = PutItemInContainer.read(messageDataReader);
                     message.contributeToTreeView(outputTreeView);
@@ -93,6 +105,49 @@ public class CM_Inventory : MessageProcessor {
         }
 
         return handled;
+    }
+
+    public class WieldItem : Message
+    {
+        public uint i_item;
+        public uint i_equipMask;
+
+        public static WieldItem read(BinaryReader binaryReader)
+        {
+            WieldItem newObj = new WieldItem();
+            newObj.i_item = binaryReader.ReadUInt32();
+            newObj.i_equipMask = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("i_item = " + Utility.FormatGuid(i_item));
+            rootNode.Nodes.Add("i_equipMask = " + Utility.FormatGuid(i_equipMask));
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
+    public class RemoveObject : Message
+    {
+        public uint i_item;
+
+        public static RemoveObject read(BinaryReader binaryReader)
+        {
+            RemoveObject newObj = new RemoveObject();
+            newObj.i_item = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("i_item = " + Utility.FormatGuid(i_item));
+            treeView.Nodes.Add(rootNode);
+        }
     }
 
     public class PutItemInContainer : Message {

--- a/aclogview/CM_Inventory.cs
+++ b/aclogview/CM_Inventory.cs
@@ -15,6 +15,12 @@ public class CM_Inventory : MessageProcessor {
 
         PacketOpcode opcode = Util.readOpcode(messageDataReader);
         switch (opcode) {
+            case PacketOpcode.INVENTORY_PUT_OBJ_IN_CONTAINER_EVENT: //0x0022
+                {
+                    PutObjectInContainerEvent message = PutObjectInContainerEvent.read(messageDataReader);
+                    message.contributeToTreeView(outputTreeView);
+                    break;
+                }
             case PacketOpcode.INVENTORY_WIELD_OBJ_EVENT: // 0x0023
                 {
                     WieldItem message = WieldItem.read(messageDataReader);
@@ -106,6 +112,36 @@ public class CM_Inventory : MessageProcessor {
 
         return handled;
     }
+
+    public class PutObjectInContainerEvent : Message
+    {
+        public uint i_objectId;
+        public uint i_container;
+        public uint i_slot;
+        public uint i_type;
+
+        public static PutObjectInContainerEvent read(BinaryReader binaryReader)
+        {
+            PutObjectInContainerEvent newObj = new PutObjectInContainerEvent();
+            newObj.i_objectId = binaryReader.ReadUInt32();
+            newObj.i_container = binaryReader.ReadUInt32();
+            newObj.i_slot = binaryReader.ReadUInt32();
+            newObj.i_type = binaryReader.ReadUInt32();
+            return newObj;
+        }
+
+        public override void contributeToTreeView(TreeView treeView)
+        {
+            TreeNode rootNode = new TreeNode(this.GetType().Name);
+            rootNode.Expand();
+            rootNode.Nodes.Add("i_objectId = " + Utility.FormatGuid(i_objectId));
+            rootNode.Nodes.Add("i_container = " + Utility.FormatGuid(i_container));
+            rootNode.Nodes.Add("i_slot = " + i_slot);
+            rootNode.Nodes.Add("i_type = " + Utility.FormatGuid(i_type));
+            treeView.Nodes.Add(rootNode);
+        }
+    }
+
 
     public class WieldItem : Message
     {


### PR DESCRIPTION
* Added INVENTORY_WIELD_OBJ_EVENT: // 0x0023.
For reference, I created the data for `35` from the Virindi XML Documentation.
* Added INVENTORY_REMOVE_OBJ_EVENT: // 0x0024.
In the PCAP I used, it showed under the UseWithTargetEvent_ID had the correlating ID.

I found that this file was really helpful: pkt_2017-1-24_1485318147_log.pcap
